### PR TITLE
Build vignettes when installing from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can install `ExploreModelMatrix` with the `remotes` (or `devtools`) package,
 like so:
 
 ```
-remotes::install_github("csoneson/ExploreModelMatrix")
+remotes::install_github("csoneson/ExploreModelMatrix", build_vignettes = TRUE, dependencies = TRUE)
 ```
 
 For this to work, you need to have the `remotes` R package installed. If you


### PR DESCRIPTION
Just a suggestion for something I've been bitten by.
Without this, people who install from GitHub won't be able to read the vignette locally.
This becomes less relevant if the package ends up on CRAN or BioC.